### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/fred-py-api-package.yml
+++ b/.github/workflows/fred-py-api-package.yml
@@ -1,6 +1,6 @@
+---
 # This workflow will install Python dependencies, run tests and lint
 # On publish event, it will build and publish a package to PyPI
-
 name: Lint, Test & Upload fred-py-api
 
 on:
@@ -13,7 +13,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -23,7 +22,6 @@ jobs:
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
       TEST_FRED_API_KEY__API: ${{ secrets.TEST_FRED_API_KEY__API }}
       TEST_FRED_API_KEY__CLI: ${{ secrets.TEST_FRED_API_KEY__CLI }}
-
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/fred-py-api-package.yml
+++ b/.github/workflows/fred-py-api-package.yml
@@ -46,7 +46,10 @@ jobs:
         coverage report -m
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
 
   pypi:
     needs: build

--- a/.github/workflows/fred-py-api-package.yml
+++ b/.github/workflows/fred-py-api-package.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -25,44 +25,52 @@ jobs:
       TEST_FRED_API_KEY__CLI: ${{ secrets.TEST_FRED_API_KEY__CLI }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[ci]
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -e .[ci]
+
     - name: Lint with black
       run: |
         # Run black on all Python files
         black --check ./
+
     - name: Test with coverage
       run: |
         coverage run -m unittest
         coverage report -m
+
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
 
   pypi:
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.12'
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install build
+        python3 -m pip install --upgrade pip build
+
     - name: Build package
-      run: python -m build
+      run: python3 -m build
+
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/fred-py-api-package.yml
+++ b/.github/workflows/fred-py-api-package.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -48,11 +48,11 @@ jobs:
         coverage report -m
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v2
 
   pypi:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/fred-py-api-package.yml
+++ b/.github/workflows/fred-py-api-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     env:
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
       TEST_FRED_API_KEY__API: ${{ secrets.TEST_FRED_API_KEY__API }}

--- a/README.md
+++ b/README.md
@@ -3,15 +3,52 @@
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/fred-py-api?style=flat)](https://pypi.org/project/fred-py-api/)
 [![codecov](https://codecov.io/gh/zachspar/fred-py-api/branch/main/graph/badge.svg?token=BG1948D8Y7)](https://codecov.io/gh/zachspar/fred-py-api)
 
-# Fred Python API
-A fully-featured FRED Command Line Interface & Python API Wrapper.
+# Fred CLI & Python API
+A fully-featured FRED Command-Line Interface & Python API Wrapper.
 
-### Documentation:
- - [fred-py-api Docs](https://fred-py-api.readthedocs.io/en/latest/)
+## Python API Documentation:
+- [fred-py-api Docs](https://fred-py-api.readthedocs.io/en/latest/)
 
-### Wiki:
- - [fred-py-api Wiki](https://github.com/zachspar/fred-py-api/wiki)
+## Wiki:
+- [fred-py-api Wiki](https://github.com/zachspar/fred-py-api/wiki)
 
-### FRED References:
- - [Create an API Key Here](https://fredaccount.stlouisfed.org/apikey)
- - [API Documentation](https://fred.stlouisfed.org/docs/api/fred/)
+## FRED References:
+- [Create an API Key Here](https://fredaccount.stlouisfed.org/apikey)
+- [API Documentation](https://fred.stlouisfed.org/docs/api/fred/)
+
+## Shell Auto-Completion:
+Fred CLI supports auto-completion for `zsh`, `bash` and `fish` shells. See instructions
+for each directly below.
+
+### `zsh` Completions
+Add this to `~/.zshrc`
+```zsh
+eval "$(_FRED_COMPLETE=zsh_source fred)"
+eval "$(_CATEGORIES_COMPLETE=zsh_source categories)"
+eval "$(_RELEASES_COMPLETE=zsh_source releases)"
+eval "$(_SERIES_COMPLETE=zsh_source series)"
+eval "$(_SOURCES_COMPLETE=zsh_source sources)"
+eval "$(_TAGS_COMPLETE=zsh_source tags)"
+```
+
+### `bash` Completions
+Add this to `~/.bashrc`
+```bash
+eval "$(_FRED_COMPLETE=bash_source fred)"
+eval "$(_CATEGORIES_COMPLETE=bash_source categories)"
+eval "$(_RELEASES_COMPLETE=bash_source releases)"
+eval "$(_SERIES_COMPLETE=bash_source series)"
+eval "$(_SOURCES_COMPLETE=bash_source sources)"
+eval "$(_TAGS_COMPLETE=bash_source tags)"
+```
+
+### `fish` Completions
+Add this to `~/.config/fish/completions/fred.fish`
+```fish
+_FRED_COMPLETE=fish_source fred | source
+_CATEGORIES_COMPLETE=fish_source categories | source
+_RELEASES_COMPLETE=fish_source releases | source
+_SERIES_COMPLETE=fish_source series | source
+_SOURCES_COMPLETE=fish_source sources | source
+_TAGS_COMPLETE=fish_source tags | source
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 project = "fred-py-api"
 copyright = "2024, Zachary Spar"
 author = "Zachary Spar"
-release = "1.1.3"
+release = "1.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fred-py-api"
-version = "1.1.3"
+version = "1.2.0"
 authors = [
     { name="Zachary Spar", email="zachspar@gmail.com" },
-    { name="Prasiddha Parthsarthy", email="prasiddha@gmail.com" },
 ]
 description = "A fully featured FRED Command Line Interface & Python API client library."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/src/fred/cli/__init__.py
+++ b/src/fred/cli/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
 
 @group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def fred_cli(ctx: click.Context, api_key: str):
     """CLI for the Federal Reserve Economic Data (FRED)."""

--- a/src/fred/cli/categories.py
+++ b/src/fred/cli/categories.py
@@ -15,6 +15,7 @@ __all__ = [
 
 @click.group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def categories(ctx: click.Context, api_key: str):
     """

--- a/src/fred/cli/releases.py
+++ b/src/fred/cli/releases.py
@@ -12,6 +12,7 @@ __all__ = ["releases", "run_releases_cli"]
 
 @click.group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def releases(ctx: click.Context, api_key: str):
     """

--- a/src/fred/cli/series.py
+++ b/src/fred/cli/series.py
@@ -15,6 +15,7 @@ __all__ = [
 
 @click.group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def series(ctx: click.Context, api_key: str):
     """

--- a/src/fred/cli/sources.py
+++ b/src/fred/cli/sources.py
@@ -15,6 +15,7 @@ __all__ = [
 
 @click.group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def sources(ctx: click.Context, api_key: str):
     """

--- a/src/fred/cli/tags.py
+++ b/src/fred/cli/tags.py
@@ -15,6 +15,7 @@ __all__ = [
 
 @click.group()
 @click.option("--api-key", type=click.STRING, required=False, help="FRED API key.")
+@click.version_option(version="1.2.0")
 @click.pass_context
 def tags(ctx: click.Context, api_key: str):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = python3.6,python3.7,python3.8,python3.9,python3.10
-isolated_build = True
-
-[testenv]
-passenv = FRED_API_KEY
-commands =
-    python3 -m unittest discover -s tests


### PR DESCRIPTION
 - bump action versions
 - bump pyproject version to `1.2.0`
 - new `--version` option (all namespaces)
 - shell autocomplete (zsh, bash, fish) documentation